### PR TITLE
Get manufacturer data and duplicate devices

### DIFF
--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -167,38 +167,24 @@ public class BluetoothManager extends GodotPlugin {
     }
 
     public void scan() {
-        sendDebugSignal("scanCalled");
         if (hasLocationPermissions()) {
-            sendDebugSignal("user hasLocationPermissions - yes");
             if (!scanning) {
-                sendDebugSignal("wasn't already scanning");
                 // Stops scanning after a predefined scan period.
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
                         scanning = false;
-                        sendDebugSignal("Stopping scan");
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
                             sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                            //return;
+                            return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
                 }, SCAN_PERIOD);
 
-                sendDebugSignal("Start scan");
-
                 scanning = true;
-                sendDebugSignal("about to call bluetoothLeScanner.startScan");
-                if (bluetoothLeScanner == null)
-                {
-                    sendDebugSignal("oh, this is never going to work, bluetoothLeScanner is null!!");
-                }
-                else{
-                    sendDebugSignal("bluetoothLeScanner is not null, should be able to call it.");
-                }
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {
@@ -223,18 +209,13 @@ public class BluetoothManager extends GodotPlugin {
             new ScanCallback() {
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
-                    sendDebugSignal("into leScanCallback");
-                    // We are only interested in devices with name
+                     // We are only interested in devices with name
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
-                        sendDebugSignal("we have a device with a name");
-                        if (!devices.containsKey(result.getDevice().getAddress())) {
-                            sendDebugSignal("it's not a device we've seen before");
+                         if (!devices.containsKey(result.getDevice().getAddress())) {
                             devices.put(result.getDevice().getAddress(), result);
                             sendNewDevice(result);
                         } else {
-                            sendDebugSignal("we've already seen this one.");
-                            if (reportDuplicates) {
-                                sendDebugSignal("...but reportDuplicates was set true, so send it anyway.");
+                             if (reportDuplicates) {
                                 sendNewDevice(result);
                             }
                         }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -53,7 +53,7 @@ public class BluetoothManager extends GodotPlugin {
     private Map<String, ScanResult> devices = new HashMap<String, ScanResult>(); // Key is the address
 
 
-    public boolean reportDuplicates = true;
+    private boolean reportDuplicates = true;
 
 
     // Permissions related functions
@@ -93,6 +93,17 @@ public class BluetoothManager extends GodotPlugin {
         return "GodotBluetooth344";
     }
 
+    public void setReportDuplicates(boolean report)
+    {
+        reportDuplicates = report;
+    }
+
+    public boolean getReportDuplicates()
+    {
+        return reportDuplicates;
+    }
+
+
     @SuppressWarnings("deprecation")
     @NonNull
     @Override
@@ -110,7 +121,9 @@ public class BluetoothManager extends GodotPlugin {
                 "unsubscribeFromCharacteristic",
                 "writeBytesToCharacteristic",
                 "writeStringToCharacteristic",
-                "readFromCharacteristic");
+                "readFromCharacteristic",
+                "setReportDuplicates",
+                "getReportDuplicates");
     }
 
     public void sendDebugSignal(String s) {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -58,12 +58,15 @@ public class BluetoothManager extends GodotPlugin {
 
     // Permissions related functions
     public boolean hasLocationPermissions() {
+        sendDebugSignal("check user has Location Permissions");
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
+            sendDebugSignal("no, they don't. Sad Face");
             return false;
         } else {
+            sendDebugSignal("Yes, they do.");
             return true;
         }
     }
@@ -138,7 +141,10 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-        deviceData.put("manufacturerData", newDevice.getScanRecord());
+        deviceData.put("manufacturerData", newDevice.getBytes());
+
+
+        //deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -161,11 +167,11 @@ public class BluetoothManager extends GodotPlugin {
     }
 
     public void scan() {
-
+        sendDebugSignal("scanCalled");
         if (hasLocationPermissions()) {
-
+            sendDebugSignal("user hasLocationPermissions - yes");
             if (!scanning) {
-
+                sendDebugSignal("wasn't already scanning");
                 // Stops scanning after a predefined scan period.
                 handler.postDelayed(new Runnable() {
                     @Override
@@ -175,8 +181,8 @@ public class BluetoothManager extends GodotPlugin {
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                            sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                            return;
+                            sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                            //return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
@@ -185,6 +191,14 @@ public class BluetoothManager extends GodotPlugin {
                 sendDebugSignal("Start scan");
 
                 scanning = true;
+                sendDebugSignal("about to call bluetoothLeScanner.startScan");
+                if (bluetoothLeScanner == null)
+                {
+                    sendDebugSignal("oh, this is never going to work, bluetoothLeScanner is null!!");
+                }
+                else{
+                    sendDebugSignal("bluetoothLeScanner is not null, should be able to call it.");
+                }
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {
@@ -198,8 +212,8 @@ public class BluetoothManager extends GodotPlugin {
             scanning = false;
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                return;
+                sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                //return;
             }
             bluetoothLeScanner.stopScan(leScanCallback);
         }
@@ -207,18 +221,22 @@ public class BluetoothManager extends GodotPlugin {
 
     private ScanCallback leScanCallback =
             new ScanCallback() {
-
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
-
+                    sendDebugSignal("into leScanCallback");
                     // We are only interested in devices with name
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
-
+                        sendDebugSignal("we have a device with a name");
                         if (!devices.containsKey(result.getDevice().getAddress())) {
+                            sendDebugSignal("it's not a device we've seen before");
                             devices.put(result.getDevice().getAddress(), result);
                             sendNewDevice(result);
-                        } else if (reportDuplicates) {
-                            sendNewDevice(result);
+                        } else {
+                            sendDebugSignal("we've already seen this one.");
+                            if (reportDuplicates) {
+                                sendDebugSignal("...but reportDuplicates was set true, so send it anyway.");
+                                sendNewDevice(result);
+                            }
                         }
                     }
                 }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -11,6 +11,7 @@ import android.bluetooth.BluetoothProfile;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -44,7 +45,8 @@ public class BluetoothManager extends GodotPlugin {
     private BluetoothLeScanner bluetoothLeScanner = mBluetoothAdapter.getBluetoothLeScanner();
     private LocationManager locationManager;
     private Handler handler = new Handler();
-    private static final long SCAN_PERIOD = 10000;
+
+    private static long ScanPeriod = 10000;
     private BluetoothGatt bluetoothGatt; // This is a reference to the connected device
 
     // Specific
@@ -103,6 +105,14 @@ public class BluetoothManager extends GodotPlugin {
         return reportDuplicates;
     }
 
+    public void setScanPeriod(long scanPeriod)
+    {
+        ScanPeriod = scanPeriod;
+    }
+    public long getScanPeriod()
+    {
+        return ScanPeriod;
+    }
 
     @SuppressWarnings("deprecation")
     @NonNull
@@ -177,9 +187,12 @@ public class BluetoothManager extends GodotPlugin {
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
-                }, SCAN_PERIOD);
+                }, ScanPeriod);
 
                 scanning = true;
+                //ScanSettings settings = new ScanSettings.Builder();
+
+
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -58,15 +58,12 @@ public class BluetoothManager extends GodotPlugin {
 
     // Permissions related functions
     public boolean hasLocationPermissions() {
-        sendDebugSignal("check user has Location Permissions");
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
-            sendDebugSignal("no, they don't. Sad Face");
             return false;
         } else {
-            sendDebugSignal("Yes, they do.");
             return true;
         }
     }
@@ -143,8 +140,6 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("rssi", newDevice.getRssi());
         deviceData.put("manufacturerData", newDevice.getScanRecord().getBytes());
 
-
-        //deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -177,7 +172,7 @@ public class BluetoothManager extends GodotPlugin {
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                            sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                            sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
                             return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
@@ -198,8 +193,8 @@ public class BluetoothManager extends GodotPlugin {
             scanning = false;
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                //return;
+                sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                return;
             }
             bluetoothLeScanner.stopScan(leScanCallback);
         }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -52,6 +52,10 @@ public class BluetoothManager extends GodotPlugin {
     private boolean connected = false;
     private Map<String, ScanResult> devices = new HashMap<String, ScanResult>(); // Key is the address
 
+
+    public boolean reportDuplicates = true;
+
+
     // Permissions related functions
     public boolean hasLocationPermissions() {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
@@ -121,7 +125,7 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-
+        deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -198,8 +202,9 @@ public class BluetoothManager extends GodotPlugin {
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
 
                         if (!devices.containsKey(result.getDevice().getAddress())) {
-
                             devices.put(result.getDevice().getAddress(), result);
+                            sendNewDevice(result);
+                        } else if (reportDuplicates) {
                             sendNewDevice(result);
                         }
                     }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -141,7 +141,7 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-        deviceData.put("manufacturerData", newDevice.getBytes());
+        deviceData.put("manufacturerData", newDevice.getScanRecord().getBytes());
 
 
         //deviceData.put("manufacturerData", newDevice.getScanRecord());

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ___
 
 **reportDuplicates**
 When set true, devices previously found in a scan will be reported with _on_device_found.
-
+---
 ### Methods
 
 **scan**

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ ___
 
 **reportDuplicates**
 When set true, devices previously found in a scan will be reported with _on_device_found.
+
 ---
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Received arguments:
 	* address: MAC address of the device
 	* name: Name of the device
 	* rssi: Signal strength of the device in dBm
+    * manufacturerData: Scan Record of the device
 ___
 
 **_on_bluetooth_status_change**
@@ -150,6 +151,10 @@ Received arguments:
 	* characteristic_uuid: The characteristic UUID
 	* bytes: They raw bytes of the payload
 ___
+### Properties
+
+**reportDuplicates**
+When set true, devices previously found in a scan will be reported with _on_device_found.
 
 ### Methods
 


### PR DESCRIPTION
This PR adds two things:
1) A flag that can be set with `setReportDuplicates(bool report)` and tested with `getReportDuplicates()` that allows the consumer to determine whether devices are reported each time they are detected, or just the first time. This currently defaults to `true`, so duplicates will be reported.

2) The object sent in `_on_device_found`, from the function `public void sendNewDevice(ScanResult newDevice)` has an additional member `manufacturerData` that contains `newDevice.getScanRecord().getBytes()`. This allows the consumer to read the BLE advert sent from the device. 

The two changes combined allow me to send data from the device, in the `manufacturerData` part of the BLE advert, so that I can receive continually updated data from it without connecting. 

For example, the following snippet retrieves the manufacturer ID and battery level from the advert, given the appropriate indexes. BLE places the manufacturer ID in a particular place, and here the battery percentage of the sensor is placed in the 20th byte. The result is added to the devices_list shown in the main sample for this repo at [GodotAndroidBluetoothDemo](https://github.com/pablojimenezmateo/GodotAndroidBluetoothDemo)

```
var INDEX_MANUFACTURER_ID_LOW = 0;   
var INDEX_MANUFACTURER_ID_HIGH = 1; 
var INDEX_BATTERY = 20;
func inflateRHBSensorAdvert(new_device):
	var offset = 10
	var advert = new_device.manufacturerData
	
	var manufacturerIdBytes = advert.subarray(offset + INDEX_MANUFACTURER_ID_LOW, offset + INDEX_MANUFACTURER_ID_HIGH)
	var manufacturerIdHex = manufacturerIdBytes.hex_encode()
	var manufacturerIdLow = manufacturerIdHex[0]+manufacturerIdHex[1]
	var manufacturerIdHigh = manufacturerIdHex[2]+manufacturerIdHex[3]

	var battery = 	advert[offset + INDEX_BATTERY]
	
	devices_list.add_item(new_device.name + " " + manufacturerIdHigh + manufacturerIdLow + " " + str(battery) + "% ")
	
```
	

The `readme.md` file has been updated to show these changes. 



