### PR TITLE
Get manufacturer data and duplicate devices - and set scan latency

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -14,7 +15,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="OPTION_INCLUDE_LIBS" value="true" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/GodotBluetooth344/src/main/AndroidManifest.xml
+++ b/GodotBluetooth344/src/main/AndroidManifest.xml
@@ -14,9 +14,9 @@
 
     <!-- Request legacy Bluetooth permissions on older devices. -->
     <uses-permission android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
+        android:maxSdkVersion="32" />
 
     <!-- Needed only if your app looks for Bluetooth devices.
          If your app doesn't use Bluetooth scan results to derive physical

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -171,7 +171,7 @@ public class BluetoothManager extends GodotPlugin {
         signals.add(new SignalInfo("_on_characteristic_finding", String.class));
         signals.add(new SignalInfo("_on_characteristic_found", org.godotengine.godot.Dictionary.class));
         signals.add(new SignalInfo("_on_characteristic_read", org.godotengine.godot.Dictionary.class));
-
+        signals.add(new SignalInfo("_on_scan_stopped", String.class));
         return signals;
     }
 
@@ -190,6 +190,8 @@ public class BluetoothManager extends GodotPlugin {
                             return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
+                        emitSignal("_on_scan_stopped", "scanTimedOut");
+
                     }
                 }, ScanPeriod);
 
@@ -213,6 +215,7 @@ public class BluetoothManager extends GodotPlugin {
                 sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
                 return;
             }
+            //emitSignal("_on_scan_stopped", "stopScan");
             bluetoothLeScanner.stopScan(leScanCallback);
         }
     }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -167,38 +167,24 @@ public class BluetoothManager extends GodotPlugin {
     }
 
     public void scan() {
-        sendDebugSignal("scanCalled");
         if (hasLocationPermissions()) {
-            sendDebugSignal("user hasLocationPermissions - yes");
             if (!scanning) {
-                sendDebugSignal("wasn't already scanning");
                 // Stops scanning after a predefined scan period.
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
                         scanning = false;
-                        sendDebugSignal("Stopping scan");
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
                             sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                            //return;
+                            return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
                 }, SCAN_PERIOD);
 
-                sendDebugSignal("Start scan");
-
                 scanning = true;
-                sendDebugSignal("about to call bluetoothLeScanner.startScan");
-                if (bluetoothLeScanner == null)
-                {
-                    sendDebugSignal("oh, this is never going to work, bluetoothLeScanner is null!!");
-                }
-                else{
-                    sendDebugSignal("bluetoothLeScanner is not null, should be able to call it.");
-                }
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {
@@ -223,18 +209,13 @@ public class BluetoothManager extends GodotPlugin {
             new ScanCallback() {
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
-                    sendDebugSignal("into leScanCallback");
-                    // We are only interested in devices with name
+                     // We are only interested in devices with name
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
-                        sendDebugSignal("we have a device with a name");
-                        if (!devices.containsKey(result.getDevice().getAddress())) {
-                            sendDebugSignal("it's not a device we've seen before");
+                         if (!devices.containsKey(result.getDevice().getAddress())) {
                             devices.put(result.getDevice().getAddress(), result);
                             sendNewDevice(result);
                         } else {
-                            sendDebugSignal("we've already seen this one.");
-                            if (reportDuplicates) {
-                                sendDebugSignal("...but reportDuplicates was set true, so send it anyway.");
+                             if (reportDuplicates) {
                                 sendNewDevice(result);
                             }
                         }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -53,7 +53,7 @@ public class BluetoothManager extends GodotPlugin {
     private Map<String, ScanResult> devices = new HashMap<String, ScanResult>(); // Key is the address
 
 
-    public boolean reportDuplicates = true;
+    private boolean reportDuplicates = true;
 
 
     // Permissions related functions
@@ -93,6 +93,17 @@ public class BluetoothManager extends GodotPlugin {
         return "GodotBluetooth344";
     }
 
+    public void setReportDuplicates(boolean report)
+    {
+        reportDuplicates = report;
+    }
+
+    public boolean getReportDuplicates()
+    {
+        return reportDuplicates;
+    }
+
+
     @SuppressWarnings("deprecation")
     @NonNull
     @Override
@@ -110,7 +121,9 @@ public class BluetoothManager extends GodotPlugin {
                 "unsubscribeFromCharacteristic",
                 "writeBytesToCharacteristic",
                 "writeStringToCharacteristic",
-                "readFromCharacteristic");
+                "readFromCharacteristic",
+                "setReportDuplicates",
+                "getReportDuplicates");
     }
 
     public void sendDebugSignal(String s) {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -58,12 +58,15 @@ public class BluetoothManager extends GodotPlugin {
 
     // Permissions related functions
     public boolean hasLocationPermissions() {
+        sendDebugSignal("check user has Location Permissions");
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
+            sendDebugSignal("no, they don't. Sad Face");
             return false;
         } else {
+            sendDebugSignal("Yes, they do.");
             return true;
         }
     }
@@ -138,7 +141,10 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-        deviceData.put("manufacturerData", newDevice.getScanRecord());
+        deviceData.put("manufacturerData", newDevice.getBytes());
+
+
+        //deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -161,11 +167,11 @@ public class BluetoothManager extends GodotPlugin {
     }
 
     public void scan() {
-
+        sendDebugSignal("scanCalled");
         if (hasLocationPermissions()) {
-
+            sendDebugSignal("user hasLocationPermissions - yes");
             if (!scanning) {
-
+                sendDebugSignal("wasn't already scanning");
                 // Stops scanning after a predefined scan period.
                 handler.postDelayed(new Runnable() {
                     @Override
@@ -175,8 +181,8 @@ public class BluetoothManager extends GodotPlugin {
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                            sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                            return;
+                            sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                            //return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
@@ -185,6 +191,14 @@ public class BluetoothManager extends GodotPlugin {
                 sendDebugSignal("Start scan");
 
                 scanning = true;
+                sendDebugSignal("about to call bluetoothLeScanner.startScan");
+                if (bluetoothLeScanner == null)
+                {
+                    sendDebugSignal("oh, this is never going to work, bluetoothLeScanner is null!!");
+                }
+                else{
+                    sendDebugSignal("bluetoothLeScanner is not null, should be able to call it.");
+                }
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {
@@ -198,8 +212,8 @@ public class BluetoothManager extends GodotPlugin {
             scanning = false;
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                return;
+                sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                //return;
             }
             bluetoothLeScanner.stopScan(leScanCallback);
         }
@@ -207,18 +221,22 @@ public class BluetoothManager extends GodotPlugin {
 
     private ScanCallback leScanCallback =
             new ScanCallback() {
-
                 @Override
                 public void onScanResult(int callbackType, ScanResult result) {
-
+                    sendDebugSignal("into leScanCallback");
                     // We are only interested in devices with name
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
-
+                        sendDebugSignal("we have a device with a name");
                         if (!devices.containsKey(result.getDevice().getAddress())) {
+                            sendDebugSignal("it's not a device we've seen before");
                             devices.put(result.getDevice().getAddress(), result);
                             sendNewDevice(result);
-                        } else if (reportDuplicates) {
-                            sendNewDevice(result);
+                        } else {
+                            sendDebugSignal("we've already seen this one.");
+                            if (reportDuplicates) {
+                                sendDebugSignal("...but reportDuplicates was set true, so send it anyway.");
+                                sendNewDevice(result);
+                            }
                         }
                     }
                 }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -11,6 +11,7 @@ import android.bluetooth.BluetoothProfile;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -44,7 +45,8 @@ public class BluetoothManager extends GodotPlugin {
     private BluetoothLeScanner bluetoothLeScanner = mBluetoothAdapter.getBluetoothLeScanner();
     private LocationManager locationManager;
     private Handler handler = new Handler();
-    private static final long SCAN_PERIOD = 10000;
+
+    private static long ScanPeriod = 10000;
     private BluetoothGatt bluetoothGatt; // This is a reference to the connected device
 
     // Specific
@@ -103,6 +105,14 @@ public class BluetoothManager extends GodotPlugin {
         return reportDuplicates;
     }
 
+    public void setScanPeriod(long scanPeriod)
+    {
+        ScanPeriod = scanPeriod;
+    }
+    public long getScanPeriod()
+    {
+        return ScanPeriod;
+    }
 
     @SuppressWarnings("deprecation")
     @NonNull
@@ -177,9 +187,12 @@ public class BluetoothManager extends GodotPlugin {
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
                     }
-                }, SCAN_PERIOD);
+                }, ScanPeriod);
 
                 scanning = true;
+                //ScanSettings settings = new ScanSettings.Builder();
+
+
                 bluetoothLeScanner.startScan(leScanCallback);
             }
         } else {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -1,5 +1,7 @@
 package com.example.godotbluetooth344;
 
+import static android.bluetooth.le.ScanSettings.SCAN_MODE_LOW_LATENCY;
+
 import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothGatt;
@@ -46,7 +48,9 @@ public class BluetoothManager extends GodotPlugin {
     private LocationManager locationManager;
     private Handler handler = new Handler();
 
-    private int ScanPeriod = 10000;
+    private ScanSettings settings = null;
+
+    private int ScanPeriod = 100000;
     private BluetoothGatt bluetoothGatt; // This is a reference to the connected device
 
     // Specific
@@ -84,9 +88,15 @@ public class BluetoothManager extends GodotPlugin {
         IntentFilter filter = new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED);
         context.registerReceiver(mReceiver, filter);
 
+
+
         // Register the listener to the Location Status
         filter = new IntentFilter(LocationManager.PROVIDERS_CHANGED_ACTION);
         context.registerReceiver(mGpsSwitchStateReceiver, filter);
+
+        ScanSettings.Builder settingBuilder = new ScanSettings.Builder();
+        settingBuilder.setScanMode(SCAN_MODE_LOW_LATENCY);
+        settings = settingBuilder.build();
     }
 
     @NonNull
@@ -196,10 +206,10 @@ public class BluetoothManager extends GodotPlugin {
                 }, ScanPeriod);
 
                 scanning = true;
-                //ScanSettings settings = new ScanSettings.Builder();
 
 
-                bluetoothLeScanner.startScan(leScanCallback);
+
+                bluetoothLeScanner.startScan(null, settings, leScanCallback );
             }
         } else {
             sendDebugSignal("Cannot start a scan because you do not have location permissions");

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -133,7 +133,9 @@ public class BluetoothManager extends GodotPlugin {
                 "writeStringToCharacteristic",
                 "readFromCharacteristic",
                 "setReportDuplicates",
-                "getReportDuplicates");
+                "getReportDuplicates",
+                "getScanPeriod",
+                "setScanPeriod");
     }
 
     public void sendDebugSignal(String s) {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -58,15 +58,12 @@ public class BluetoothManager extends GodotPlugin {
 
     // Permissions related functions
     public boolean hasLocationPermissions() {
-        sendDebugSignal("check user has Location Permissions");
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
                         != PackageManager.PERMISSION_GRANTED) {
-            sendDebugSignal("no, they don't. Sad Face");
             return false;
         } else {
-            sendDebugSignal("Yes, they do.");
             return true;
         }
     }
@@ -143,8 +140,6 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("rssi", newDevice.getRssi());
         deviceData.put("manufacturerData", newDevice.getScanRecord().getBytes());
 
-
-        //deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -177,7 +172,7 @@ public class BluetoothManager extends GodotPlugin {
 
                         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                            sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                            sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
                             return;
                         }
                         bluetoothLeScanner.stopScan(leScanCallback);
@@ -198,8 +193,8 @@ public class BluetoothManager extends GodotPlugin {
             scanning = false;
             if (ActivityCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
 
-                sendDebugSignal("might not stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
-                //return;
+                sendDebugSignal("Cannot stop a scan because you do not have Manifest.permission.BLUETOOTH_SCAN");
+                return;
             }
             bluetoothLeScanner.stopScan(leScanCallback);
         }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -52,6 +52,10 @@ public class BluetoothManager extends GodotPlugin {
     private boolean connected = false;
     private Map<String, ScanResult> devices = new HashMap<String, ScanResult>(); // Key is the address
 
+
+    public boolean reportDuplicates = true;
+
+
     // Permissions related functions
     public boolean hasLocationPermissions() {
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
@@ -121,7 +125,7 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-
+        deviceData.put("manufacturerData", newDevice.getScanRecord());
         emitSignal("_on_device_found", deviceData);
     }
 
@@ -198,8 +202,9 @@ public class BluetoothManager extends GodotPlugin {
                     if (result != null && result.getDevice() != null && result.getDevice().getAddress() != null && result.getScanRecord().getDeviceName() != null) {
 
                         if (!devices.containsKey(result.getDevice().getAddress())) {
-
                             devices.put(result.getDevice().getAddress(), result);
+                            sendNewDevice(result);
+                        } else if (reportDuplicates) {
                             sendNewDevice(result);
                         }
                     }

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -46,7 +46,7 @@ public class BluetoothManager extends GodotPlugin {
     private LocationManager locationManager;
     private Handler handler = new Handler();
 
-    private static long ScanPeriod = 10000;
+    private int ScanPeriod = 10000;
     private BluetoothGatt bluetoothGatt; // This is a reference to the connected device
 
     // Specific
@@ -105,14 +105,15 @@ public class BluetoothManager extends GodotPlugin {
         return reportDuplicates;
     }
 
-    public void setScanPeriod(long scanPeriod)
+    public void setScanPeriod(int scanPeriod)
     {
         ScanPeriod = scanPeriod;
     }
-    public long getScanPeriod()
-    {
-        return ScanPeriod;
-    }
+
+    public int getScanPeriod() { return ScanPeriod; }
+
+
+    public boolean hasGetScanPeriod() { return true; }
 
     @SuppressWarnings("deprecation")
     @NonNull
@@ -132,10 +133,11 @@ public class BluetoothManager extends GodotPlugin {
                 "writeBytesToCharacteristic",
                 "writeStringToCharacteristic",
                 "readFromCharacteristic",
-                "setReportDuplicates",
-                "getReportDuplicates",
+                "setScanPeriod",
                 "getScanPeriod",
-                "setScanPeriod");
+                "hasGetScanPeriod",
+                "setReportDuplicates",
+                "getReportDuplicates");
     }
 
     public void sendDebugSignal(String s) {

--- a/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
+++ b/GodotBluetooth344/src/main/java/com/example/godotbluetooth344/BluetoothManager.java
@@ -141,7 +141,7 @@ public class BluetoothManager extends GodotPlugin {
         deviceData.put("name", newDevice.getScanRecord().getDeviceName());
         deviceData.put("address", newDevice.getDevice().getAddress());
         deviceData.put("rssi", newDevice.getRssi());
-        deviceData.put("manufacturerData", newDevice.getBytes());
+        deviceData.put("manufacturerData", newDevice.getScanRecord().getBytes());
 
 
         //deviceData.put("manufacturerData", newDevice.getScanRecord());

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ___
 
 **reportDuplicates**
 When set true, devices previously found in a scan will be reported with _on_device_found.
-
+---
 ### Methods
 
 **scan**

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ ___
 
 **reportDuplicates**
 When set true, devices previously found in a scan will be reported with _on_device_found.
+
 ---
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Received arguments:
 	* address: MAC address of the device
 	* name: Name of the device
 	* rssi: Signal strength of the device in dBm
+    * manufacturerData: Scan Record of the device
 ___
 
 **_on_bluetooth_status_change**
@@ -150,6 +151,10 @@ Received arguments:
 	* characteristic_uuid: The characteristic UUID
 	* bytes: They raw bytes of the payload
 ___
+### Properties
+
+**reportDuplicates**
+When set true, devices previously found in a scan will be reported with _on_device_found.
 
 ### Methods
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.1' apply false
-    id 'com.android.library' version '7.1.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 25 15:54:32 GMT-05:00 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Allow the consuming class to get and set the scanning period.

Set the scan mode to SCAN_MODE_LOW_LATENCY. This changed the repeated discovery time of my BLE device from an average of around 450ms to an average of 66ms.
